### PR TITLE
feat: add delete route for snapshot schedules and standardize api routes

### DIFF
--- a/register/src/index.js
+++ b/register/src/index.js
@@ -79,6 +79,22 @@ function createErrorResponse(errorMessage, request, statusCode) {
   return new Response(null, { status: statusCode, headers });
 }
 
+function resolveOrgSite(request, data) {
+  const urlOrg = request.params?.org;
+  const urlSite = request.params?.site;
+  const bodyOrg = data?.org;
+  const bodySite = data?.site;
+
+  if ((urlOrg && bodyOrg && urlOrg !== bodyOrg) || (urlSite && bodySite && urlSite !== bodySite)) {
+    return { error: 'URL org/site must match body org/site' };
+  }
+
+  return {
+    org: urlOrg || bodyOrg,
+    site: urlSite || bodySite,
+  };
+}
+
 export async function setApiKey(env, org, site, apiKey) {
   try {
     if (!env || !env.SCHEDULER_KV) {
@@ -182,7 +198,12 @@ export async function registerRequest(request, env) {
       console.log('Register Request: Invalid body. Please provide org, site and apiKey');
       return createErrorResponse('Invalid body. Please provide org, site and apiKey', null, 400);
     }
-    const { org, site, apiKey } = data;
+    const { org, site, error } = resolveOrgSite(request, data);
+    if (error) {
+      console.log(`Register Request: ${error}`);
+      return createErrorResponse(error, null, 400);
+    }
+    const { apiKey } = data;
     if (!org || !site || !apiKey) {
       console.log('Register Request: Invalid body. Please provide org, site and apiKey');
       return createErrorResponse('Invalid body. Please provide org, site and apiKey', null, 400);
@@ -254,9 +275,12 @@ export async function updateSchedule(request, env) {
       return createErrorResponse('Invalid body. Please provide org, site and snapshotId', request, 400);
     }
 
-    const {
-      org, site, snapshotId, approved = false, userId,
-    } = data;
+    const { org, site, error } = resolveOrgSite(request, data);
+    if (error) {
+      console.log(`Update Schedule Request: ${error}`);
+      return createErrorResponse(error, request, 400);
+    }
+    const { snapshotId, approved = false, userId } = data;
     if (!org || !site || !snapshotId) {
       console.log('Update Schedule Request: Invalid body. Please provide org, site and snapshotId');
       return createErrorResponse('Invalid body. Please provide org, site and snapshotId', request, 400);
@@ -452,9 +476,12 @@ export async function schedulePage(request, env) {
       return createErrorResponse('Invalid body. Please provide org, site, path, scheduledPublish, and userId', request, 400);
     }
 
-    const {
-      org, site, path, scheduledPublish, userId,
-    } = data;
+    const { org, site, error } = resolveOrgSite(request, data);
+    if (error) {
+      console.log(`Schedule Page Request: ${error}`);
+      return createErrorResponse(error, request, 400);
+    }
+    const { path, scheduledPublish, userId } = data;
     if (!org || !site || !path || !scheduledPublish || !userId) {
       console.log('Schedule Page Request: Invalid body. Please provide org, site, path, scheduledPublish, and userId');
       return createErrorResponse('Invalid body. Please provide org, site, path, scheduledPublish, and userId', request, 400);
@@ -665,12 +692,16 @@ router.options('/register/:org/:site', (request) => createResponse(null, request
 router.options('/schedule', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/page/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 
 router.post('/register', async (request, env) => registerRequest(request, env));
+router.post('/register/:org/:site', async (request, env) => registerRequest(request, env));
 router.get('/register/:org/:site', async (request, env) => isRegistered(request, env));
 router.post('/schedule', async (request, env) => updateSchedule(request, env));
 router.post('/schedule/page', async (request, env) => schedulePage(request, env));
+router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env));
+router.post('/schedule/:org/:site', async (request, env) => updateSchedule(request, env));
 router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env));
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));
 // catch all for invalid routes

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -763,6 +763,7 @@ const router = IttyRouter();
 router.options('/register', (request) => createResponse(null, request, { status: 204 }));
 router.options('/register/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site', (request) => createResponse(null, request, { status: 204 }));

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -683,6 +683,79 @@ export async function deletePageSchedule(request, env) {
   }
 }
 
+/**
+ * Delete a scheduled snapshot publish.
+ * Route: DELETE /schedule/snapshot/:org/:site/*
+ * The wildcard captures the snapshot ID (which may contain slashes).
+ * @param {Object} request - The incoming request
+ * @param {Object} env - The environment object
+ */
+export async function deleteSnapshotSchedule(request, env) {
+  try {
+    const { org, site } = request.params;
+    const snapshotId = request.params['*'];
+    if (!org || !site || !snapshotId) {
+      return createErrorResponse('Invalid URL. Expected /schedule/snapshot/:org/:site/:snapshotId', request, 400);
+    }
+
+    const apiKey = await getApiKey(env, org, site);
+    if (!apiKey) {
+      return createErrorResponse('Org/site not registered', request, 404);
+    }
+
+    const authToken = request.headers.get('Authorization');
+    if (!authToken) {
+      return createErrorResponse('Unauthorized', request, 401);
+    }
+    const authorized = await isAuthorized(authToken, org, site, false);
+    if (!authorized) {
+      return createErrorResponse('Unauthorized', request, 401);
+    }
+
+    let scheduleData = {};
+    try {
+      const existingSchedule = await env.R2_BUCKET.get('schedule.json');
+      if (existingSchedule) {
+        scheduleData = await existingSchedule.json();
+      }
+    } catch (err) {
+      console.warn('Could not read existing schedule data:', err);
+      return createErrorResponse('Could not retrieve schedule data', request, 500);
+    }
+
+    const orgSiteKey = `${org}--${site}`;
+    if (!scheduleData[orgSiteKey] || !scheduleData[orgSiteKey][snapshotId]) {
+      return createErrorResponse('No schedule found for this snapshot', request, 404);
+    }
+
+    delete scheduleData[orgSiteKey][snapshotId];
+
+    if (Object.keys(scheduleData[orgSiteKey]).length === 0) {
+      delete scheduleData[orgSiteKey];
+    }
+
+    await env.R2_BUCKET.put('schedule.json', JSON.stringify(scheduleData, null, 2));
+
+    console.log(`Snapshot schedule deleted for ${orgSiteKey}: ${snapshotId}`);
+
+    return createResponse(JSON.stringify({
+      success: true,
+      message: `Snapshot schedule deleted for ${org}/${site}`,
+      org,
+      site,
+      snapshotId,
+    }), request, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (err) {
+    console.error('Delete snapshot schedule failed: ', request, err);
+    return createErrorResponse('Delete snapshot schedule failed: Internal server error', request, 500);
+  }
+}
+
 // Create a new router
 const router = IttyRouter();
 
@@ -693,6 +766,7 @@ router.options('/schedule', (request) => createResponse(null, request, { status:
 router.options('/schedule/page', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/snapshot/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 
 router.post('/register', async (request, env) => registerRequest(request, env));
@@ -703,6 +777,7 @@ router.post('/schedule/page', async (request, env) => schedulePage(request, env)
 router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env));
 router.post('/schedule/:org/:site', async (request, env) => updateSchedule(request, env));
 router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env));
+router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env));
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));
 // catch all for invalid routes
 router.all('*', () => createErrorResponse('404, not found!', null, 404));

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -769,15 +769,15 @@ router.options('/schedule/page/:org/:site', (request) => createResponse(null, re
 router.options('/schedule/snapshot/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 
-router.post('/register', async (request, env) => registerRequest(request, env));
-router.post('/register/:org/:site', async (request, env) => registerRequest(request, env));
+router.post('/register', async (request, env) => registerRequest(request, env)); // old route for register
+router.post('/register/:org/:site', async (request, env) => registerRequest(request, env)); // new route for register
 router.get('/register/:org/:site', async (request, env) => isRegistered(request, env));
-router.post('/schedule', async (request, env) => updateSchedule(request, env));
-router.post('/schedule/page', async (request, env) => schedulePage(request, env));
-router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env));
-router.post('/schedule/:org/:site', async (request, env) => updateSchedule(request, env));
-router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env));
-router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env));
+router.post('/schedule', async (request, env) => updateSchedule(request, env)); // old route for schedule snapshot
+router.post('/schedule/page', async (request, env) => schedulePage(request, env)); // old route for schedule page
+router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env)); // new route for schedule page
+router.post('/schedule/:org/:site', async (request, env) => updateSchedule(request, env)); // new route for schedule snapshot
+router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env)); // new route for delete page schedule
+router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env)); // new route for delete snapshot schedule
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));
 // catch all for invalid routes
 router.all('*', () => createErrorResponse('404, not found!', null, 404));

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -767,7 +767,7 @@ router.options('/schedule/page', (request) => createResponse(null, request, { st
 router.options('/schedule/page/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/snapshot/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
-router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/snapshot/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 
 router.post('/register', async (request, env) => registerRequest(request, env)); // old route for register
 router.post('/register/:org/:site', async (request, env) => registerRequest(request, env)); // new route for register
@@ -775,7 +775,7 @@ router.get('/register/:org/:site', async (request, env) => isRegistered(request,
 router.post('/schedule', async (request, env) => updateSchedule(request, env)); // old route for schedule snapshot
 router.post('/schedule/page', async (request, env) => schedulePage(request, env)); // old route for schedule page
 router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env)); // new route for schedule page
-router.post('/schedule/:org/:site', async (request, env) => updateSchedule(request, env)); // new route for schedule snapshot
+router.post('/schedule/snapshot/:org/:site', async (request, env) => updateSchedule(request, env)); // new route for schedule snapshot
 router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env)); // new route for delete page schedule
 router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env)); // new route for delete snapshot schedule
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -593,15 +593,14 @@ export async function schedulePage(request, env) {
 
 /**
  * Delete a scheduled page publish.
- * Route: DELETE /schedule/page/:org/:site/*
- * The wildcard captures the page path (which may contain slashes).
+ * Route: DELETE /schedule/page/:org/:site/:path+
+ * The greedy param captures the page path (which may contain slashes).
  * @param {Object} request - The incoming request
  * @param {Object} env - The environment object
  */
 export async function deletePageSchedule(request, env) {
   try {
-    const { org, site } = request.params;
-    const pagePath = request.params['*'];
+    const { org, site, path: pagePath } = request.params;
     if (!org || !site || !pagePath) {
       return createErrorResponse('Invalid URL. Expected /schedule/page/:org/:site/:path', request, 400);
     }
@@ -685,15 +684,14 @@ export async function deletePageSchedule(request, env) {
 
 /**
  * Delete a scheduled snapshot publish.
- * Route: DELETE /schedule/snapshot/:org/:site/*
- * The wildcard captures the snapshot ID (which may contain slashes).
+ * Route: DELETE /schedule/snapshot/:org/:site/:snapshotId+
+ * The greedy param captures the snapshot ID (which may contain slashes).
  * @param {Object} request - The incoming request
  * @param {Object} env - The environment object
  */
 export async function deleteSnapshotSchedule(request, env) {
   try {
-    const { org, site } = request.params;
-    const snapshotId = request.params['*'];
+    const { org, site, snapshotId } = request.params;
     if (!org || !site || !snapshotId) {
       return createErrorResponse('Invalid URL. Expected /schedule/snapshot/:org/:site/:snapshotId', request, 400);
     }
@@ -765,9 +763,9 @@ router.options('/register/:org/:site', (request) => createResponse(null, request
 router.options('/schedule', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page', (request) => createResponse(null, request, { status: 204 }));
-router.options('/schedule/page/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/page/:org/:site/:path+', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/page/:org/:site', (request) => createResponse(null, request, { status: 204 }));
-router.options('/schedule/snapshot/:org/:site/*', (request) => createResponse(null, request, { status: 204 }));
+router.options('/schedule/snapshot/:org/:site/:snapshotId+', (request) => createResponse(null, request, { status: 204 }));
 router.options('/schedule/snapshot/:org/:site', (request) => createResponse(null, request, { status: 204 }));
 
 router.post('/register', async (request, env) => registerRequest(request, env)); // old route for register
@@ -777,8 +775,8 @@ router.post('/schedule', async (request, env) => updateSchedule(request, env)); 
 router.post('/schedule/page', async (request, env) => schedulePage(request, env)); // old route for schedule page
 router.post('/schedule/page/:org/:site', async (request, env) => schedulePage(request, env)); // new route for schedule page
 router.post('/schedule/snapshot/:org/:site', async (request, env) => updateSchedule(request, env)); // new route for schedule snapshot
-router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageSchedule(request, env)); // new route for delete page schedule
-router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env)); // new route for delete snapshot schedule
+router.delete('/schedule/page/:org/:site/:path+', async (request, env) => deletePageSchedule(request, env));
+router.delete('/schedule/snapshot/:org/:site/:snapshotId+', async (request, env) => deleteSnapshotSchedule(request, env));
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));
 // catch all for invalid routes
 router.all('*', (request) => createErrorResponse('404, not found!', request, 404));

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -196,34 +196,34 @@ export async function registerRequest(request, env) {
     const data = await request.json();
     if (!data) {
       console.log('Register Request: Invalid body. Please provide org, site and apiKey');
-      return createErrorResponse('Invalid body. Please provide org, site and apiKey', null, 400);
+      return createErrorResponse('Invalid body. Please provide org, site and apiKey', request, 400);
     }
     const { org, site, error } = resolveOrgSite(request, data);
     if (error) {
       console.log(`Register Request: ${error}`);
-      return createErrorResponse(error, null, 400);
+      return createErrorResponse(error, request, 400);
     }
     const { apiKey } = data;
     if (!org || !site || !apiKey) {
       console.log('Register Request: Invalid body. Please provide org, site and apiKey');
-      return createErrorResponse('Invalid body. Please provide org, site and apiKey', null, 400);
+      return createErrorResponse('Invalid body. Please provide org, site and apiKey', request, 400);
     }
 
     const authToken = request.headers.get('Authorization');
     if (!authToken) {
       console.log('Register Request: No authorization token found');
-      return createErrorResponse('Unauthorized', null, 401);
+      return createErrorResponse('Unauthorized', request, 401);
     }
     const authorized = await isAuthorized(authToken, org, site, true);
     if (!authorized) {
       console.log('Register Request: isAuthorized returned false');
-      return createErrorResponse('Unauthorized', null, 401);
+      return createErrorResponse('Unauthorized', request, 401);
     }
     // set the api key for the org/site
     const success = await setApiKey(env, org, site, apiKey);
     if (!success) {
       console.log('Register Request: Failed to set API key');
-      return createErrorResponse('Register Request failed: Internal server error', null, 500);
+      return createErrorResponse('Register Request failed: Internal server error', request, 500);
     }
     return createResponse(JSON.stringify({ success: true }), request, {
       status: 200,
@@ -231,7 +231,7 @@ export async function registerRequest(request, env) {
     });
   } catch (err) {
     console.error('Register Request failed: ', request, err);
-    return createErrorResponse('Register Request failed: Internal server error', null, 500);
+    return createErrorResponse('Register Request failed: Internal server error', request, 500);
   }
 }
 
@@ -780,7 +780,7 @@ router.delete('/schedule/page/:org/:site/*', async (request, env) => deletePageS
 router.delete('/schedule/snapshot/:org/:site/*', async (request, env) => deleteSnapshotSchedule(request, env)); // new route for delete snapshot schedule
 router.get('/schedule/:org/:site', async (request, env) => getSchedule(request, env));
 // catch all for invalid routes
-router.all('*', () => createErrorResponse('404, not found!', null, 404));
+router.all('*', (request) => createErrorResponse('404, not found!', request, 404));
 
 // Wrapper that initializes global environment and routes requests
 export default {

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -546,14 +546,14 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
-  it('should update a snapshot schedule via POST /schedule/:org/:site', async () => {
+  it('should update a snapshot schedule via POST /schedule/snapshot/:org/:site', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;
     const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
     global.fetch = mockFetchForUrlRouteTests({ scheduledPublish: validFutureDate });
 
     const { env, getStoredSchedule } = createRouteTestEnv();
-    const request = createJsonRequest('http://localhost/schedule/org1/site1', {
+    const request = createJsonRequest('http://localhost/schedule/snapshot/org1/site1', {
       snapshotId: 'snapshot1',
       userId: 'user@example.com',
     });
@@ -618,13 +618,13 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
-  it('should reject mismatched org/site between URL and body for schedule', async () => {
+  it('should reject mismatched org/site between URL and body for schedule snapshot', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;
     global.fetch = mockFetchForUrlRouteTests();
 
     const { env, getStoredSchedule } = createRouteTestEnv();
-    const request = createJsonRequest('http://localhost/schedule/org1/site1', {
+    const request = createJsonRequest('http://localhost/schedule/snapshot/org1/site1', {
       org: 'other-org',
       site: 'other-site',
       snapshotId: 'snapshot1',

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -1840,6 +1840,211 @@ describe('DeletePageSchedule API Tests', () => {
   });
 });
 
+describe('DeleteSnapshotSchedule API Tests', () => {
+  function mockFetchWithSnapshotAuth({ authorized = true } = {}) {
+    return async (url) => {
+      if (url.includes('admin.hlx.page/snapshot') && url.endsWith('/main')) {
+        return { ok: authorized };
+      }
+      return { ok: true };
+    };
+  }
+
+  it('should delete a scheduled snapshot successfully', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    let storedSchedule = null;
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchWithSnapshotAuth();
+
+    const mockEnvWithCapture = {
+      ...mockEnv,
+      R2_BUCKET: {
+        get: async (key) => {
+          if (key === 'schedule.json') {
+            return {
+              json: async () => ({
+                'org1--site1': {
+                  'main/2025-06-15-12-00-00': {
+                    type: 'snapshot',
+                    scheduledPublish: '2025-06-15T12:00:00Z',
+                    userId: 'user@example.com',
+                  },
+                  'main/2025-06-16-12-00-00': {
+                    type: 'snapshot',
+                    scheduledPublish: '2025-06-16T12:00:00Z',
+                    userId: 'user@example.com',
+                  },
+                },
+              }),
+            };
+          }
+          return null;
+        },
+        put: async (key, value) => {
+          if (key === 'schedule.json') {
+            storedSchedule = JSON.parse(value);
+          }
+          return true;
+        },
+      },
+    };
+
+    const request = {
+      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnvWithCapture);
+    const responseData = await response.json();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.success, true);
+    assert.strictEqual(responseData.snapshotId, 'main/2025-06-15-12-00-00');
+
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1']['main/2025-06-15-12-00-00'], undefined);
+    assert(storedSchedule['org1--site1']['main/2025-06-16-12-00-00'], 'Other snapshot should remain');
+
+    global.fetch = originalFetch;
+  });
+
+  it('should clean up empty org/site key after last snapshot is deleted', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    let storedSchedule = null;
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchWithSnapshotAuth();
+
+    const mockEnvWithCapture = {
+      ...mockEnv,
+      R2_BUCKET: {
+        get: async (key) => {
+          if (key === 'schedule.json') {
+            return {
+              json: async () => ({
+                'org1--site1': {
+                  'main/2025-06-15-12-00-00': {
+                    type: 'snapshot',
+                    scheduledPublish: '2025-06-15T12:00:00Z',
+                    userId: 'user@example.com',
+                  },
+                },
+              }),
+            };
+          }
+          return null;
+        },
+        put: async (key, value) => {
+          if (key === 'schedule.json') {
+            storedSchedule = JSON.parse(value);
+          }
+          return true;
+        },
+      },
+    };
+
+    const request = {
+      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnvWithCapture);
+    assert.strictEqual(response.status, 200);
+
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1'], undefined);
+
+    global.fetch = originalFetch;
+  });
+
+  it('should return 404 when snapshot is not scheduled', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchWithSnapshotAuth();
+
+    const request = {
+      params: { org: 'org1', site: 'site1', '*': 'main/nonexistent-snapshot' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnv);
+    const errorHeader = response.headers.get('X-Error');
+    assert.strictEqual(response.status, 404);
+    assert.strictEqual(errorHeader, 'No schedule found for this snapshot');
+
+    global.fetch = originalFetch;
+  });
+
+  it('should return 400 when snapshot ID is missing from URL', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    const request = {
+      params: { org: 'org1', site: 'site1' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnv);
+    assert.strictEqual(response.status, 400);
+  });
+
+  it('should return 401 when no Authorization header is provided', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    const request = {
+      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      headers: {
+        get: () => null,
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnv);
+    assert.strictEqual(response.status, 401);
+  });
+
+  it('should return 401 when user does not have snapshot list access', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchWithSnapshotAuth({ authorized: false });
+
+    const request = {
+      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnv);
+    assert.strictEqual(response.status, 401);
+
+    global.fetch = originalFetch;
+  });
+
+  it('should return 404 for unregistered org/site', async () => {
+    const { deleteSnapshotSchedule } = await import('../src/index.js');
+
+    const request = {
+      params: { org: 'unregistered', site: 'site', '*': 'main/2025-06-15-12-00-00' },
+      headers: {
+        get: (name) => (name === 'Authorization' ? 'token test-token' : null),
+      },
+    };
+
+    const response = await deleteSnapshotSchedule(request, mockEnv);
+    assert.strictEqual(response.status, 404);
+  });
+});
+
 describe('Authorization Tests', () => {
   it('should return true for valid admin authorization', async () => {
     const { isAuthorized } = await import('../src/index.js');

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -662,6 +662,29 @@ describe('URL Format Route Tests', () => {
 
     global.fetch = originalFetch;
   });
+
+  it('should route DELETE /schedule/snapshot/:org/:site/* to deleteSnapshotSchedule', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const { env } = createRouteTestEnv();
+    const request = new Request('http://localhost/schedule/snapshot/org1/site1/main/2025-06-15-12-00-00', {
+      method: 'DELETE',
+      headers: { Authorization: 'token test-token', Origin: 'https://org1.aem.live' },
+    });
+
+    const response = await worker.fetch(request, env, {});
+
+    // itty-router v5 does not populate params['*'] for wildcard routes, so deleteSnapshotSchedule
+    // returns 400 with the expected error message. Verify the route is wired (not a generic 404)
+    // and that CORS headers are present in the error response.
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.headers.get('X-Error'), 'Invalid URL. Expected /schedule/snapshot/:org/:site/:snapshotId');
+    assert(response.headers.get('Access-Control-Allow-Methods'), 'CORS headers should be present in error response');
+
+    global.fetch = originalFetch;
+  });
 });
 
 describe('IsRegistered API Tests', () => {

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -663,7 +663,7 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
-  it('should route DELETE /schedule/snapshot/:org/:site/* to deleteSnapshotSchedule', async () => {
+  it('should route DELETE /schedule/snapshot/:org/:site/:snapshotId+ to deleteSnapshotSchedule', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;
     global.fetch = mockFetchForUrlRouteTests();
@@ -676,11 +676,9 @@ describe('URL Format Route Tests', () => {
 
     const response = await worker.fetch(request, env, {});
 
-    // itty-router v5 does not populate params['*'] for wildcard routes, so deleteSnapshotSchedule
-    // returns 400 with the expected error message. Verify the route is wired (not a generic 404)
-    // and that CORS headers are present in the error response.
-    assert.strictEqual(response.status, 400);
-    assert.strictEqual(response.headers.get('X-Error'), 'Invalid URL. Expected /schedule/snapshot/:org/:site/:snapshotId');
+    // The route should reach deleteSnapshotSchedule (not a generic 404).
+    // It may return 404 (unregistered) or 401 depending on mock setup, but not 404 "not found!".
+    assert.notStrictEqual(response.headers.get('X-Error'), '404, not found!');
     assert(response.headers.get('Access-Control-Allow-Methods'), 'CORS headers should be present in error response');
 
     global.fetch = originalFetch;
@@ -1644,7 +1642,7 @@ describe('DeletePageSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'my-page' },
+      params: { org: 'org1', site: 'site1', path: 'my-page' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1700,7 +1698,7 @@ describe('DeletePageSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'blog/2025/my-article' },
+      params: { org: 'org1', site: 'site1', path: 'blog/2025/my-article' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1753,7 +1751,7 @@ describe('DeletePageSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'only-page' },
+      params: { org: 'org1', site: 'site1', path: 'only-page' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1775,7 +1773,7 @@ describe('DeletePageSchedule API Tests', () => {
     global.fetch = mockFetchWithPublishPermission();
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'nonexistent-page' },
+      params: { org: 'org1', site: 'site1', path: 'nonexistent-page' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1807,7 +1805,7 @@ describe('DeletePageSchedule API Tests', () => {
     const { deletePageSchedule } = await import('../src/index.js');
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'my-page' },
+      params: { org: 'org1', site: 'site1', path: 'my-page' },
       headers: {
         get: () => null,
       },
@@ -1834,7 +1832,7 @@ describe('DeletePageSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'my-page' },
+      params: { org: 'org1', site: 'site1', path: 'my-page' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1852,7 +1850,7 @@ describe('DeletePageSchedule API Tests', () => {
     const { deletePageSchedule } = await import('../src/index.js');
 
     const request = {
-      params: { org: 'unregistered', site: 'site', '*': 'my-page' },
+      params: { org: 'unregistered', site: 'site', path: 'my-page' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1914,7 +1912,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      params: { org: 'org1', site: 'site1', snapshotId: 'main/2025-06-15-12-00-00' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1970,7 +1968,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     };
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      params: { org: 'org1', site: 'site1', snapshotId: 'main/2025-06-15-12-00-00' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -1992,7 +1990,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     global.fetch = mockFetchWithSnapshotAuth();
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'main/nonexistent-snapshot' },
+      params: { org: 'org1', site: 'site1', snapshotId: 'main/nonexistent-snapshot' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -2024,7 +2022,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     const { deleteSnapshotSchedule } = await import('../src/index.js');
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      params: { org: 'org1', site: 'site1', snapshotId: 'main/2025-06-15-12-00-00' },
       headers: {
         get: () => null,
       },
@@ -2041,7 +2039,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     global.fetch = mockFetchWithSnapshotAuth({ authorized: false });
 
     const request = {
-      params: { org: 'org1', site: 'site1', '*': 'main/2025-06-15-12-00-00' },
+      params: { org: 'org1', site: 'site1', snapshotId: 'main/2025-06-15-12-00-00' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },
@@ -2057,7 +2055,7 @@ describe('DeleteSnapshotSchedule API Tests', () => {
     const { deleteSnapshotSchedule } = await import('../src/index.js');
 
     const request = {
-      params: { org: 'unregistered', site: 'site', '*': 'main/2025-06-15-12-00-00' },
+      params: { org: 'unregistered', site: 'site', snapshotId: 'main/2025-06-15-12-00-00' },
       headers: {
         get: (name) => (name === 'Authorization' ? 'token test-token' : null),
       },

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -81,6 +81,87 @@ global.fetch = async (url) => {
   return { ok: false };
 };
 
+function createJsonRequest(url, body) {
+  return new Request(url, {
+    method: 'POST',
+    headers: {
+      Authorization: 'token test-token',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function createRouteTestEnv({ initialSchedule = {}, apiKey = 'test-api-key' } = {}) {
+  let storedSchedule = null;
+  let storedApiKey = null;
+
+  return {
+    env: {
+      R2_BUCKET: {
+        get: async (key) => {
+          if (key === 'schedule.json') {
+            return { json: async () => initialSchedule };
+          }
+          return null;
+        },
+        put: async (key, value) => {
+          if (key === 'schedule.json') {
+            storedSchedule = JSON.parse(value);
+          }
+          return true;
+        },
+      },
+      SCHEDULER_KV: {
+        get: async (key) => (key === 'org1--site1--apiKey' ? apiKey : null),
+        put: async (key, value) => {
+          storedApiKey = { key, value };
+          return true;
+        },
+      },
+    },
+    getStoredSchedule: () => storedSchedule,
+    getStoredApiKey: () => storedApiKey,
+  };
+}
+
+function mockFetchForUrlRouteTests({ canPublish = true, scheduledPublish } = {}) {
+  const nextScheduledPublish = scheduledPublish
+    || new Date(Date.now() + 10 * 60 * 1000).toISOString();
+  return async (url) => {
+    if (url.includes('admin.hlx.page/config')) {
+      return { ok: true };
+    }
+    if (url.includes('admin.hlx.page/snapshot') && url.endsWith('/main')) {
+      return { ok: true };
+    }
+    if (url.includes('admin.hlx.page/snapshot')) {
+      return {
+        ok: true,
+        json: async () => ({
+          manifest: {
+            metadata: {
+              scheduledPublish: nextScheduledPublish,
+            },
+          },
+        }),
+      };
+    }
+    if (url.includes('admin.hlx.page/status/')) {
+      return {
+        ok: true,
+        json: async () => ({
+          live: { status: 200, permissions: canPublish ? ['read', 'write'] : ['read'] },
+        }),
+      };
+    }
+    if (url.includes('admin.hlx.page/log/')) {
+      return { ok: true };
+    }
+    return { ok: false, status: 404, statusText: 'Not Found' };
+  };
+}
+
 describe('Schedule API Tests', () => {
   it('should persist userId in schedule.json when provided', async () => {
     const { updateSchedule } = await import('../src/index.js');
@@ -438,6 +519,148 @@ describe('Register API Tests', () => {
 
     const response = await registerRequest(request, mockEnv);
     assert.strictEqual(response.status, 400);
+  });
+});
+
+describe('URL Format Route Tests', () => {
+  it('should register successfully via POST /register/:org/:site', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const { env, getStoredApiKey } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/register/org1/site1', {
+      apiKey: 'route-api-key',
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.success, true);
+    assert.deepStrictEqual(getStoredApiKey(), {
+      key: 'org1--site1--apiKey',
+      value: 'route-api-key',
+    });
+
+    global.fetch = originalFetch;
+  });
+
+  it('should update a snapshot schedule via POST /schedule/:org/:site', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    global.fetch = mockFetchForUrlRouteTests({ scheduledPublish: validFutureDate });
+
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/org1/site1', {
+      snapshotId: 'snapshot1',
+      userId: 'user@example.com',
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+    const storedSchedule = getStoredSchedule();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.snapshotId, 'snapshot1');
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1'].snapshot1.type, 'snapshot');
+    assert.strictEqual(storedSchedule['org1--site1'].snapshot1.scheduledPublish, validFutureDate);
+
+    global.fetch = originalFetch;
+  });
+
+  it('should schedule a page via POST /schedule/page/:org/:site', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
+      path: '/my-page',
+      scheduledPublish: validFutureDate,
+      userId: 'user@example.com',
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+    const storedSchedule = getStoredSchedule();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.path, '/my-page');
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1']['/my-page'].type, 'page');
+    assert.strictEqual(storedSchedule['org1--site1']['/my-page'].userId, 'user@example.com');
+
+    global.fetch = originalFetch;
+  });
+
+  it('should reject mismatched org/site between URL and body for register', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const { env, getStoredApiKey } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/register/org1/site1', {
+      org: 'other-org',
+      site: 'other-site',
+      apiKey: 'route-api-key',
+    });
+
+    const response = await worker.fetch(request, env, {});
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.headers.get('X-Error'), 'URL org/site must match body org/site');
+    assert.strictEqual(getStoredApiKey(), null);
+
+    global.fetch = originalFetch;
+  });
+
+  it('should reject mismatched org/site between URL and body for schedule', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/org1/site1', {
+      org: 'other-org',
+      site: 'other-site',
+      snapshotId: 'snapshot1',
+    });
+
+    const response = await worker.fetch(request, env, {});
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.headers.get('X-Error'), 'URL org/site must match body org/site');
+    assert.strictEqual(getStoredSchedule(), null);
+
+    global.fetch = originalFetch;
+  });
+
+  it('should reject mismatched org/site between URL and body for schedule page', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
+      org: 'other-org',
+      site: 'other-site',
+      path: '/my-page',
+      scheduledPublish: validFutureDate,
+      userId: 'user@example.com',
+    });
+
+    const response = await worker.fetch(request, env, {});
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.headers.get('X-Error'), 'URL org/site must match body org/site');
+    assert.strictEqual(getStoredSchedule(), null);
+
+    global.fetch = originalFetch;
   });
 });
 


### PR DESCRIPTION
- adding delete route for snapshots that are scheduled (in addition to scheduled page that was already there)
- standardizing all the api endpoints to be in line with helix (adding new ones in the API for now). As we update apps using these endpoints to use the new ones, we will deprecate the old API routes