### PR TITLE
fix: agentic plugins token fix

### DIFF
--- a/register/src/index.js
+++ b/register/src/index.js
@@ -73,7 +73,9 @@ function createResponse(body, request, options = {}) {
 // Helper function to create error Response with X-Error header and add console logs
 // Pass request for CORS-enabled endpoints, or null for non-CORS endpoints
 function createErrorResponse(errorMessage, request, statusCode) {
-  const context = request?.method && request?.url ? ` ${request.method} ${request.url}` : '';
+  const context = request?.method && request?.url
+    ? ` ${request.method} ${new URL(request.url).pathname}`
+    : '';
   const line = `[error ${statusCode}]${context} ${errorMessage}`;
   if (statusCode >= 500) {
     console.error(line);
@@ -239,7 +241,7 @@ export async function registerRequest(request, env) {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    console.error('Register Request failed: ', request, err);
+    console.error('Register Request failed: ', err);
     return createErrorResponse('Register Request failed: Internal server error', request, 500);
   }
 }
@@ -369,7 +371,7 @@ export async function updateSchedule(request, env) {
       },
     });
   } catch (err) {
-    console.error('Update schedule failed: ', request, err);
+    console.error('Update schedule failed: ', err);
     return createErrorResponse('Update schedule failed: Internal server error', request, 500);
   }
 }
@@ -444,7 +446,7 @@ export async function getSchedule(request, env) {
       status: 200, headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    console.error('Get schedule failed: ', request, err);
+    console.error('Get schedule failed: ', err);
     return createErrorResponse('Get schedule failed: Internal server error', request, 500);
   }
 }
@@ -582,7 +584,7 @@ export async function schedulePage(request, env) {
       status: 200, headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    console.error('Schedule page failed: ', request, err);
+    console.error('Schedule page failed: ', err);
     return createErrorResponse('Schedule page failed: Internal server error', request, 500);
   }
 }
@@ -680,7 +682,7 @@ export async function deletePageSchedule(request, env) {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    console.error('Delete page schedule failed: ', request, err);
+    console.error('Delete page schedule failed: ', err);
     return createErrorResponse('Delete page schedule failed: Internal server error', request, 500);
   }
 }
@@ -767,7 +769,7 @@ export async function deleteSnapshotSchedule(request, env) {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err) {
-    console.error('Delete snapshot schedule failed: ', request, err);
+    console.error('Delete snapshot schedule failed: ', err);
     return createErrorResponse('Delete snapshot schedule failed: Internal server error', request, 500);
   }
 }

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -70,9 +70,17 @@ function createResponse(body, request, options = {}) {
   return new Response(body, { ...options, headers });
 }
 
-// Helper function to create error Response with X-Error header
+// Helper function to create error Response with X-Error header and add console logs
 // Pass request for CORS-enabled endpoints, or null for non-CORS endpoints
 function createErrorResponse(errorMessage, request, statusCode) {
+  const context = request?.method && request?.url ? ` ${request.method} ${request.url}` : '';
+  const line = `[error ${statusCode}]${context} ${errorMessage}`;
+  if (statusCode >= 500) {
+    console.error(line);
+  } else {
+    console.warn(line);
+  }
+
   const headers = {
     'X-Error': errorMessage,
     ...(request ? getCorsHeaders(request) : {}),

--- a/register/src/index.js
+++ b/register/src/index.js
@@ -504,16 +504,15 @@ export async function schedulePage(request, env) {
     let resolvedUserId;
 
     if (authToken) {
-      // DA mode — preserve existing behavior
-      const { userId } = data;
-      if (!userId) {
-        return createErrorResponse('Invalid body. Please provide userId', request, 400);
-      }
+      // DA mode — use a body-supplied userId when present, otherwise derive the
+      // identity from the token (parity with the delete handlers, so agentic MCP
+      // callers that never pass a userId still work).
       const canPublish = await hasPublishPermission(authToken, org, site, normalizedPath);
       if (!canPublish) {
         return createErrorResponse('Forbidden: you do not have publish permission for this page', request, 403);
       }
-      resolvedUserId = userId;
+      const { userId } = data;
+      resolvedUserId = userId || await resolveDaUserId({ authToken, org, site });
     } else {
       // Sidekick mode — log-readback proof
       const { nonce } = data;

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -597,6 +597,64 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
+  it('should resolve userId from the token profile when omitted from the body (agentic MCP path)', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    const routeFetch = mockFetchForUrlRouteTests();
+    global.fetch = async (url, opts) => {
+      if (url.includes('admin.hlx.page/profile/')) {
+        return { ok: true, json: async () => ({ profile: { email: 'resolved@example.com' } }) };
+      }
+      return routeFetch(url, opts);
+    };
+
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    // No userId in the body — it must be derived from the forwarded token.
+    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
+      path: '/my-page',
+      scheduledPublish: validFutureDate,
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+    const storedSchedule = getStoredSchedule();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.path, '/my-page');
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1']['/my-page'].userId, 'resolved@example.com');
+
+    global.fetch = originalFetch;
+  });
+
+  it('should still schedule (attribution is best-effort) when no body userId is provided and the token profile cannot be resolved', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    // Base route mock has no /profile/ branch, so the profile lookup 404s and
+    // resolveDaUserId returns null. The token already passed the publish-permission
+    // check, so scheduling proceeds with a null userId (attribution is best-effort).
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { env, getStoredSchedule } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
+      path: '/my-page',
+      scheduledPublish: validFutureDate,
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+    const storedSchedule = getStoredSchedule();
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(responseData.path, '/my-page');
+    assert(storedSchedule, 'Schedule should be stored');
+    assert.strictEqual(storedSchedule['org1--site1']['/my-page'].userId, null);
+
+    global.fetch = originalFetch;
+  });
+
   it('should reject mismatched org/site between URL and body for register', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -721,32 +721,6 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
-  it('should return the error message in both the X-Error header and the JSON body', async () => {
-    const { default: worker } = await import('../src/index.js');
-    const originalFetch = global.fetch;
-    global.fetch = mockFetchForUrlRouteTests();
-
-    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
-    const { env } = createRouteTestEnv();
-    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
-      org: 'other-org',
-      site: 'other-site',
-      path: '/my-page',
-      scheduledPublish: validFutureDate,
-      userId: 'user@example.com',
-    });
-
-    const response = await worker.fetch(request, env, {});
-    const responseData = await response.json();
-
-    assert.strictEqual(response.status, 400);
-    assert.strictEqual(response.headers.get('X-Error'), 'URL org/site must match body org/site');
-    assert.strictEqual(response.headers.get('Content-Type'), 'application/json');
-    assert.strictEqual(responseData.error, 'URL org/site must match body org/site');
-
-    global.fetch = originalFetch;
-  });
-
   it('should route DELETE /schedule/snapshot/:org/:site/:snapshotId+ to deleteSnapshotSchedule', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;

--- a/register/test/schedule.test.js
+++ b/register/test/schedule.test.js
@@ -721,6 +721,32 @@ describe('URL Format Route Tests', () => {
     global.fetch = originalFetch;
   });
 
+  it('should return the error message in both the X-Error header and the JSON body', async () => {
+    const { default: worker } = await import('../src/index.js');
+    const originalFetch = global.fetch;
+    global.fetch = mockFetchForUrlRouteTests();
+
+    const validFutureDate = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const { env } = createRouteTestEnv();
+    const request = createJsonRequest('http://localhost/schedule/page/org1/site1', {
+      org: 'other-org',
+      site: 'other-site',
+      path: '/my-page',
+      scheduledPublish: validFutureDate,
+      userId: 'user@example.com',
+    });
+
+    const response = await worker.fetch(request, env, {});
+    const responseData = await response.json();
+
+    assert.strictEqual(response.status, 400);
+    assert.strictEqual(response.headers.get('X-Error'), 'URL org/site must match body org/site');
+    assert.strictEqual(response.headers.get('Content-Type'), 'application/json');
+    assert.strictEqual(responseData.error, 'URL org/site must match body org/site');
+
+    global.fetch = originalFetch;
+  });
+
   it('should route DELETE /schedule/snapshot/:org/:site/:snapshotId+ to deleteSnapshotSchedule', async () => {
     const { default: worker } = await import('../src/index.js');
     const originalFetch = global.fetch;


### PR DESCRIPTION
### Fix: agentic MCP schedule_page_publish fails with "Please provide userId"

**Changes**

1. schedulePage DA mode — derive identity from the token (register/src/index.js)
- Use a body-supplied userId when present; otherwise derive it from the token via resolveDaUserId({ authToken, org, site }) — restoring parity with the delete handlers.

2. createErrorResponse — log errors so they appear in observability (register/src/index.js)
- Cloudflare observability (Workers Logs, [observability] enabled = true) captures console.* output, not response bodies or the X-Error header — so error responses were previously invisible in the dashboard.
- createErrorResponse now logs every error: console.error for 5xx, console.warn for 4xx, including method + URL context. The X-Error header (consumed by the MCP client) is unchanged.

**Tests**

- ✅ schedulePage DA mode derives userId from the token profile when the body omits it (agentic MCP path).
- ✅ schedulePage still schedules with best-effort attribution (userId: null) when the profile lookup can't be resolved.
- Existing DA-mode test still covers the body-userId short-circuit.
- 94 tests pass, lint clean.